### PR TITLE
Enforce expected channel ordering on SNIRF load

### DIFF
--- a/Functions/File_IO/snirf2ndot.m
+++ b/Functions/File_IO/snirf2ndot.m
@@ -248,7 +248,7 @@ if type == 'snirf'
             end
 
             % Re-order channels by wavelenth (EVR 230510)
-            [info.pairs.WL,I] = sort(info.pairs.WL)
+            [info.pairs.WL,I] = sort(info.pairs.WL);
             data = data(I,:);
             info.pairs.Src = info.pairs.Src(I);
             info.pairs.Det = info.pairs.Det(I);

--- a/Functions/File_IO/snirf2ndot.m
+++ b/Functions/File_IO/snirf2ndot.m
@@ -246,10 +246,18 @@ if type == 'snirf'
                 end
                 
             end
+
+            % Re-order channels by wavelenth (EVR 230510)
+            [info.pairs.WL,I] = sort(info.pairs.WL)
+            data = data(I,:);
+            info.pairs.Src = info.pairs.Src(I);
+            info.pairs.Det = info.pairs.Det(I);
+            info.pairs.lambda = info.pairs.lambda(I);
+
             end
             if ~isfield(snf, 'original_header') 
-                gridTemp.spos3=snf.nirs.probe.sourcePos3D;
-                gridTemp.dpos3=snf.nirs.probe.detectorPos3D;
+                gridTemp.spos2=snf.nirs.probe.sourcePos2D;
+                gridTemp.dpos2=snf.nirs.probe.detectorPos2D;
                 if isfield(snf.nirs.probe, 'sourcePos3D') && isfield(snf.nirs.probe, 'detectorPos3D')
                     gridTemp.spos3=snf.nirs.probe.sourcePos3D;
                     gridTemp.dpos3=snf.nirs.probe.detectorPos3D;
@@ -275,7 +283,8 @@ if type == 'snirf'
                 info.pairs.r3d=tempInfo.pairs.r3d(IdxB);
                 info.pairs.r2d = tempInfo.pairs.r2d(IdxB);
                 info.pairs.NN = tempInfo.pairs.NN(IdxB);
-                
+                info.pairs.lambda = tempInfo.pairs.lambda(IdxB);
+
                 % Moved from Line 241 (3/8/23 ES)
                 avg_r3d = mean(info.pairs.r3d);
                 if (avg_r3d >=1) && (avg_r3d <=10) % Changed max_log to min_log 2/1/23


### PR DESCRIPTION
Certain functions in NeuroDOT expect that channels are ordered by wavelength, for example, the falloff curve. However, this layout is not enforced when loading from a SNIRF file.

The current behaviour can thus cause figures such as the following to be produced:

![screenshot_2023-06-20_at_11 56 21](https://github.com/WUSTL-ORL/NeuroDOT/assets/6370657/3337c201-6ef7-42d3-bd24-75cc0b71d60e)

When fixed by this PR, the same figure is now correctly rendered:

![screenshot_2023-06-19_at_22 16 21](https://github.com/WUSTL-ORL/NeuroDOT/assets/6370657/8994692d-c228-4c46-b4d1-2593061f2005)

