### PR TITLE
fix: TtestWelch computes one-tailed p-value, not two-tailed as documented

### DIFF
--- a/Functions/Analysis/TtestWelch.m
+++ b/Functions/Analysis/TtestWelch.m
@@ -45,7 +45,7 @@ dof=((se1+se2).^2)./(((se1.^2)./(n1-1))+((se2.^2)./(n2-1)));
 dof(~isfinite(dof))=0;
 
 %% P-values: 2-tailed p-value. to 1st approx, halve if want 1-tailed.
-p=1-tcdf(abs(t),dof); 
+p=2*tcdf(-abs(t),dof);
 p(~isfinite(p))=0;
 
 %% Cohen's d


### PR DESCRIPTION
## Summary
- `TtestWelch.m` line 48: `p=1-tcdf(abs(t),dof)` is a one-tailed p-value.
  The comment on line 47 says "2-tailed p-value".
- Fix: `p=2*tcdf(-abs(t),dof)` (numerically stable two-tailed form).

## Reproducer

```matlab
rng(42);
X1 = randn(100,1);
X2 = randn(100,1) + 0.3;

[~, p_nd] = TtestWelch(X1', X2');       % NeuroDOT
[~, p_ml] = ttest2(X1, X2, 'Vartype', 'unequal');  % MATLAB built-in

fprintf('NeuroDOT p = %.6f\n', p_nd);
fprintf('MATLAB   p = %.6f\n', p_ml);
fprintf('Ratio      = %.1f\n', p_ml / p_nd);  % prints 2.0
```

## Impact
All p-values from this function are half the correct two-tailed value,
inflating false positive rates for group-level contrasts and statistical maps.

## Test plan
- [ ] Verify output matches MATLAB `ttest2(...,'Vartype','unequal')` on synthetic data
- [ ] Verify edge cases: equal means (t=0), zero variance, single sample